### PR TITLE
Update link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repo contains branches of sample apps and is used for quickly testing and
 reviewing changes 🔬
 
-These apps aren't too interesting, but one you make will be! Check out [api.slack.com/future](https://api.slack.com/future) if you're curious!
+These apps aren't too interesting, but one you make will be! Check out
+[api.slack.com/automation](https://api.slack.com/automation) if you're curious!
 
 ## Apps on branches
 


### PR DESCRIPTION
This PR updates the link found on the README, now pointing to `/automation`! 🤖 🎉 Closes #1.